### PR TITLE
regabi: support arm64 on go1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 ### RegAbi ( Go1.17 / Go1.18)
 
 * amd64 support regabi
-* arm64 set env `GOEXPERIMENT=noregabi` on Go1.18
+* arm64 support regabi
+* ppc64 set env `GOEXPERIMENT=noregabi` on Go1.18
 
 ### gossa command line
 ```

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.16
 require (
 	github.com/goplus/gop v1.1.0-beta2
 	github.com/goplus/gox v1.9.6
-	github.com/goplus/reflectx v0.8.2
+	github.com/goplus/reflectx v0.8.3
 	golang.org/x/tools v0.1.8
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/goplus/gop v1.1.0-beta2 h1:1IVY7FNFhfSeZLEjj1j3kJmDZKD0RX79iBE7syWkas
 github.com/goplus/gop v1.1.0-beta2/go.mod h1:sf1PYB7IUrzmxBHBz0oJ/lKBuberHiZ/qvHIcm6UcBY=
 github.com/goplus/gox v1.9.6 h1:02w1XDGjpIqrELpSWMhQJ3khiVByo4LlLrcxPxvh1kw=
 github.com/goplus/gox v1.9.6/go.mod h1:PznHkzl2HARBf7+s2reqcwKm1Z1a6Wae6EntQEh0iJI=
-github.com/goplus/reflectx v0.8.2 h1:hXCF3TtMo0eQILZ2z131U9S+MH+21hzXyHDvoG6uSCk=
-github.com/goplus/reflectx v0.8.2/go.mod h1:XPDe5lYQ/8FN05bhqv6r1hhLxwmYIkZ5UvIkN1GNRYg=
+github.com/goplus/reflectx v0.8.3 h1:kr26rbZI1EzOL1QNa3nCKGPjLRtL2JIbXae4rmLBYTU=
+github.com/goplus/reflectx v0.8.3/go.mod h1:XPDe5lYQ/8FN05bhqv6r1hhLxwmYIkZ5UvIkN1GNRYg=
 github.com/qiniu/x v1.11.5 h1:TYr5cl4g2yoHAZeDK4MTjKF6CMoG+IHlCDvvM5qym6U=
 github.com/qiniu/x v1.11.5/go.mod h1:03Ni9tj+N2h2aKnAz+6N0Xfl8FwMEDRC2PAlxekASDs=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/interp_test.go
+++ b/interp_test.go
@@ -216,17 +216,17 @@ func init() {
 	gorootTestSkips["atomicload"] = "slow"
 
 	ver := runtime.Version()
-	if strings.HasPrefix(ver, "go1.17.") || strings.HasPrefix(ver, "go1.18.") {
+	if strings.HasPrefix(ver, "go1.17") || strings.HasPrefix(ver, "go1.18") {
 		gorootTestSkips["fixedbugs/issue45045.go"] = "runtime.SetFinalizer"
 		gorootTestSkips["fixedbugs/issue46725.go"] = "runtime.SetFinalizer"
 		gorootTestSkips["abi/fibish.go"] = "very slow"
 		gorootTestSkips["abi/fibish_closure.go"] = "very slow"
 		gorootTestSkips["abi/uglyfib.go"] = "very slow"
 		gorootTestSkips["fixedbugs/issue23017.go"] = "BUG"
-	} else if strings.HasPrefix(ver, "go1.15.") {
+	} else if strings.HasPrefix(ver, "go1.15") {
 		gorootTestSkips["fixedbugs/issue15039.go"] = "BUG, uint64 -> string"
 		gorootTestSkips["fixedbugs/issue9355.go"] = "TODO, chdir"
-	} else if strings.HasPrefix(ver, "go1.14.") {
+	} else if strings.HasPrefix(ver, "go1.14") {
 		gorootTestSkips["fixedbugs/issue9355.go"] = "TODO, chdir"
 	}
 

--- a/interp_test.go
+++ b/interp_test.go
@@ -233,6 +233,7 @@ func init() {
 	if runtime.GOOS == "windows" {
 		gorootTestSkips["env.go"] = "skip GOARCH"
 		gorootTestSkips["fixedbugs/issue15002.go"] = "skip windows"
+		gorootTestSkips["fixedbugs/issue5493.go"] = "skip windows"
 
 		skips := make(map[string]string)
 		for k, v := range gorootTestSkips {

--- a/interp_test.go
+++ b/interp_test.go
@@ -213,7 +213,7 @@ func init() {
 	gorootTestSkips["fixedbugs/issue30116u.go"] = "BUG, slice bound check"
 	gorootTestSkips["fixedbugs/bug295.go"] = "skip, gossa not import testing"
 	gorootTestSkips["fixedbugs/issue27695.go"] = "runtime/debug.SetGCPercent"
-	gorootTestSkips["atomicload"] = "slow"
+	gorootTestSkips["atomicload.go"] = "slow"
 
 	ver := runtime.Version()
 	if strings.HasPrefix(ver, "go1.17") || strings.HasPrefix(ver, "go1.18") {

--- a/interp_test.go
+++ b/interp_test.go
@@ -213,9 +213,10 @@ func init() {
 	gorootTestSkips["fixedbugs/issue30116u.go"] = "BUG, slice bound check"
 	gorootTestSkips["fixedbugs/bug295.go"] = "skip, gossa not import testing"
 	gorootTestSkips["fixedbugs/issue27695.go"] = "runtime/debug.SetGCPercent"
+	gorootTestSkips["atomicload"] = "slow"
 
 	ver := runtime.Version()
-	if strings.HasPrefix(ver, "go1.17.") {
+	if strings.HasPrefix(ver, "go1.17.") || strings.HasPrefix(ver, "go1.18.") {
 		gorootTestSkips["fixedbugs/issue45045.go"] = "runtime.SetFinalizer"
 		gorootTestSkips["fixedbugs/issue46725.go"] = "runtime.SetFinalizer"
 		gorootTestSkips["abi/fibish.go"] = "very slow"


### PR DESCRIPTION
update dep reflectx for support regabi arm64 on go1.18