### PR TITLE
call external

### DIFF
--- a/context.go
+++ b/context.go
@@ -67,6 +67,7 @@ func (c *Context) SetDebug(fn func(*DebugInfo)) {
 	c.debugFunc = fn
 }
 
+// match func fullname and signature
 func (c *Context) SetOverrideFunction(key string, fn interface{}) {
 	if fn == nil {
 		delete(c.override, key)

--- a/context.go
+++ b/context.go
@@ -67,6 +67,7 @@ func (c *Context) SetDebug(fn func(*DebugInfo)) {
 	c.debugFunc = fn
 }
 
+// register external function to override function.
 // match func fullname and signature
 func (c *Context) SetOverrideFunction(key string, fn interface{}) {
 	if fn == nil {

--- a/context.go
+++ b/context.go
@@ -41,13 +41,14 @@ type Loader interface {
 }
 
 type Context struct {
-	Loader      Loader          // types loader
-	Mode        Mode            // mode
-	ParserMode  parser.Mode     // parser mode
-	BuilderMode ssa.BuilderMode // ssa builder mode
-	External    types.Importer  // external import
-	Sizes       types.Sizes
-	DebugFunc   func(*DebugInfo)
+	Loader      Loader                   // types loader
+	Mode        Mode                     // mode
+	ParserMode  parser.Mode              // parser mode
+	BuilderMode ssa.BuilderMode          // ssa builder mode
+	External    types.Importer           // external import
+	Sizes       types.Sizes              // types size for package unsafe
+	debugFunc   func(*DebugInfo)         // debug func
+	override    map[string]reflect.Value // override function
 }
 
 func NewContext(mode Mode) *Context {
@@ -56,13 +57,22 @@ func NewContext(mode Mode) *Context {
 		Mode:        mode,
 		ParserMode:  parser.AllErrors,
 		BuilderMode: 0, //ssa.SanityCheckFunctions,
+		override:    make(map[string]reflect.Value),
 	}
 	return ctx
 }
 
 func (c *Context) SetDebug(fn func(*DebugInfo)) {
 	c.BuilderMode |= ssa.GlobalDebug
-	c.DebugFunc = fn
+	c.debugFunc = fn
+}
+
+func (c *Context) SetOverrideFunction(key string, fn interface{}) {
+	if fn == nil {
+		delete(c.override, key)
+	} else {
+		c.override[key] = reflect.ValueOf(fn)
+	}
 }
 
 func (c *Context) LoadDir(fset *token.FileSet, path string) (pkgs []*ssa.Package, first error) {
@@ -155,11 +165,7 @@ func (c *Context) RunFunc(mainPkg *ssa.Package, fnname string, args ...Value) (r
 }
 
 func (c *Context) NewInterp(mainPkg *ssa.Package) (*Interp, error) {
-	r, err := NewInterp(c.Loader, mainPkg, c.Mode)
-	if err == nil && c.DebugFunc != nil {
-		r.setDebug(c.DebugFunc)
-	}
-	return r, err
+	return NewInterp(c, mainPkg)
 }
 
 func (c *Context) TestPkg(pkgs []*ssa.Package, input string, args []string) error {
@@ -192,7 +198,7 @@ func (c *Context) TestPkg(pkgs []*ssa.Package, input string, args []string) erro
 	}
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	for _, pkg := range testPkgs {
-		interp, err := NewInterp(c.Loader, pkg, c.Mode)
+		interp, err := NewInterp(c, pkg)
 		if err != nil {
 			failed = true
 			fmt.Printf("create interp failed: %v\n", err)

--- a/interp.go
+++ b/interp.go
@@ -442,9 +442,9 @@ func (i *Interp) call(caller *frame, fn value, args []value, ssaArgs []ssa.Value
 	case *ssa.Builtin:
 		return i.callBuiltin(caller, fn, args, ssaArgs)
 	case reflect.Value:
-		return i.callReflect(caller, fn, args, nil)
+		return i.callExternal(caller, fn, args, nil)
 	default:
-		return i.callReflect(caller, reflect.ValueOf(fn), args, nil)
+		return i.callExternal(caller, reflect.ValueOf(fn), args, nil)
 	}
 	panic(fmt.Sprintf("cannot call %T %v", fn, reflect.ValueOf(fn).Kind()))
 }
@@ -462,9 +462,9 @@ func (i *Interp) callDiscardsResult(caller *frame, fn value, args []value, ssaAr
 	case *ssa.Builtin:
 		i.callBuiltinDiscardsResult(caller, fn, args, ssaArgs)
 	case reflect.Value:
-		i.callReflectDiscardsResult(caller, fn, args, nil)
+		i.callExternalDiscardsResult(caller, fn, args, nil)
 	default:
-		i.callReflectDiscardsResult(caller, reflect.ValueOf(fn), args, nil)
+		i.callExternalDiscardsResult(caller, reflect.ValueOf(fn), args, nil)
 	}
 }
 
@@ -560,7 +560,7 @@ func (i *Interp) callFunctionByStack(caller *frame, pfn *Function, ir int, ia []
 	fr.stack = nil
 }
 
-func (i *Interp) callReflect(caller *frame, fn reflect.Value, args []value, env []value) value {
+func (i *Interp) callExternal(caller *frame, fn reflect.Value, args []value, env []value) value {
 	if caller != nil && caller.deferid != 0 {
 		i.deferMap.Store(caller.deferid, caller)
 	}
@@ -605,7 +605,7 @@ func (i *Interp) callReflect(caller *frame, fn reflect.Value, args []value, env 
 		return tuple(res)
 	}
 }
-func (i *Interp) callReflectDiscardsResult(caller *frame, fn reflect.Value, args []value, env []value) {
+func (i *Interp) callExternalDiscardsResult(caller *frame, fn reflect.Value, args []value, env []value) {
 	if caller != nil && caller.deferid != 0 {
 		i.deferMap.Store(caller.deferid, caller)
 	}
@@ -635,7 +635,7 @@ func (i *Interp) callReflectDiscardsResult(caller *frame, fn reflect.Value, args
 	}
 }
 
-func (i *Interp) callReflectByStack(caller *frame, fn reflect.Value, ir int, ia []int) {
+func (i *Interp) callExternalByStack(caller *frame, fn reflect.Value, ir int, ia []int) {
 	if caller.deferid != 0 {
 		i.deferMap.Store(caller.deferid, caller)
 	}

--- a/opblock.go
+++ b/opblock.go
@@ -995,7 +995,7 @@ func makeCallInstr(pfn *Function, interp *Interp, instr ssa.Value, call *ssa.Cal
 				panic(fmt.Errorf("no code for function: %v", fn))
 			}
 			return func(fr *frame) {
-				interp.callReflectByStack(fr, ext, ir, ia)
+				interp.callExternalByStack(fr, ext, ir, ia)
 			}
 		}
 		ifn := interp.funcs[fn]
@@ -1023,7 +1023,7 @@ func makeCallInstr(pfn *Function, interp *Interp, instr ssa.Value, call *ssa.Cal
 		case *ssa.Builtin:
 			interp.callBuiltinByStack(fr, fn.Name(), call.Args, ir, ia)
 		default:
-			interp.callReflectByStack(fr, reflect.ValueOf(fn), ir, ia)
+			interp.callExternalByStack(fr, reflect.ValueOf(fn), ir, ia)
 		}
 	}
 }
@@ -1084,6 +1084,6 @@ func makeCallMethodInstr(interp *Interp, instr ssa.Value, call *ssa.CallCommon, 
 		if !found {
 			panic(fmt.Errorf("no code for method: %v.%v", rtype, mname))
 		}
-		interp.callReflectByStack(fr, ext, ir, ia)
+		interp.callExternalByStack(fr, ext, ir, ia)
 	}
 }

--- a/package.go
+++ b/package.go
@@ -73,7 +73,7 @@ var (
 	externValues = make(map[string]reflect.Value)
 )
 
-// register external interface
+// register external function for no function body
 func RegisterExternal(key string, i interface{}) {
 	externValues[key] = reflect.ValueOf(i)
 }

--- a/visit.go
+++ b/visit.go
@@ -80,9 +80,14 @@ func (visit *visitor) function(fn *ssa.Function) {
 		return
 	}
 	visit.seen[fn] = true
+	fnPath := fn.String()
+	if f := visit.intp.ctx.override[fnPath]; f.Kind() == reflect.Func {
+		fn.Blocks = nil
+		return
+	}
 	if fn.Blocks == nil {
 		if _, ok := visit.pkgs[fn.Pkg]; ok {
-			if _, ok = externValues[fn.String()]; !ok {
+			if _, ok = externValues[fnPath]; !ok {
 				panic(fmt.Errorf("%v: missing function body", visit.intp.fset.Position(fn.Pos())))
 			}
 		}

--- a/visit.go
+++ b/visit.go
@@ -82,7 +82,9 @@ func (visit *visitor) function(fn *ssa.Function) {
 	visit.seen[fn] = true
 	if fn.Blocks == nil {
 		if _, ok := visit.pkgs[fn.Pkg]; ok {
-			panic(fmt.Errorf("%v: missing function body", visit.intp.fset.Position(fn.Pos())))
+			if _, ok = externValues[fn.String()]; !ok {
+				panic(fmt.Errorf("%v: missing function body", visit.intp.fset.Position(fn.Pos())))
+			}
 		}
 		return
 	}

--- a/visit.go
+++ b/visit.go
@@ -81,7 +81,8 @@ func (visit *visitor) function(fn *ssa.Function) {
 	}
 	visit.seen[fn] = true
 	fnPath := fn.String()
-	if f := visit.intp.ctx.override[fnPath]; f.Kind() == reflect.Func {
+	if f, ok := visit.intp.ctx.override[fnPath]; ok &&
+		visit.intp.preToType(fn.Type()) == f.Type() {
 		fn.Blocks = nil
 		return
 	}


### PR DESCRIPTION
* gossa.RegisterExternal . register external function used by no function body
```
// source
package main

func fib(n int) (i int)

func main() {
	println(fib(35))
}
```

```
// run for gossa
func fib(n int) (i int) {
	if n < 2 {
		return n
	}
	return fib(n-2) + fib(n-1)
}
gossa.RegisterExternal("main.fib",fib)
```
new api
* ctx.SetOverrideFunction, register external function to override function. 
```
// source
package main

func fib(n int) (i int) {
	if n < 2 {
		return n
	}
	return fib(n-2) + fib(n-1)
}

func main() {
	println(fib(35))
}
```
```
// run for gossa
func fib(n int) (i int) {
	if n < 2 {
		return n
	}
	return fib(n-2) + fib(n-1)
}
ctx.SetOverrideFunction("main.fib",fib)
```


