### PR TITLE
optimize and fast non tail recursion

### DIFF
--- a/context.go
+++ b/context.go
@@ -52,6 +52,7 @@ type Context struct {
 	debugFunc   func(*DebugInfo)         // debug func
 	override    map[string]reflect.Value // override function
 	output      io.Writer                // capture print/println output
+	callForPool int                      // least call count for enable function pool
 }
 
 // NewContext create a new Context
@@ -62,11 +63,17 @@ func NewContext(mode Mode) *Context {
 		ParserMode:  parser.AllErrors,
 		BuilderMode: 0, //ssa.SanityCheckFunctions,
 		override:    make(map[string]reflect.Value),
+		callForPool: 64,
 	}
 	if mode&EnableDumpInstr != 0 {
 		ctx.BuilderMode |= ssa.PrintFunctions
 	}
 	return ctx
+}
+
+// SetLeastCallForEnablePool set least call count for enable function pool, default 64
+func (c *Context) SetLeastCallForEnablePool(count int) {
+	c.callForPool = count
 }
 
 func (c *Context) SetDebug(fn func(*DebugInfo)) {

--- a/interp.go
+++ b/interp.go
@@ -123,6 +123,8 @@ func (i *Interp) loadFunction(fn *ssa.Function) *Function {
 		Main:             fn.Blocks[0],
 		mapUnderscoreKey: make(map[types.Type]bool),
 		index:            make(map[ssa.Value]uint32),
+		narg:             len(fn.Params),
+		nenv:             len(fn.FreeVars),
 	}
 	i.funcs[fn] = pfn
 	return pfn
@@ -415,13 +417,11 @@ func (i *Interp) callDiscardsResult(caller *frame, fn value, args []value, ssaAr
 
 func (i *Interp) callFunction(caller *frame, pfn *Function, args []value, env []value) (result value) {
 	fr := pfn.allocFrame(caller)
-	na := len(args)
-	for i := 0; i < na; i++ {
+	for i := 0; i < pfn.narg; i++ {
 		fr.stack[i] = args[i]
 	}
-	ne := len(env)
-	for i := 0; i < ne; i++ {
-		fr.stack[na+i] = env[i]
+	for i := 0; i < pfn.nenv; i++ {
+		fr.stack[pfn.narg+i] = env[i]
 	}
 	fr.run()
 	n := len(fr.results)
@@ -440,13 +440,11 @@ func (i *Interp) callFunction(caller *frame, pfn *Function, args []value, env []
 
 func (i *Interp) callFunctionByReflect(caller *frame, typ reflect.Type, pfn *Function, args []reflect.Value, env []value) (results []reflect.Value) {
 	fr := pfn.allocFrame(caller)
-	na := len(args)
-	for i := 0; i < na; i++ {
+	for i := 0; i < pfn.narg; i++ {
 		fr.stack[i] = args[i].Interface()
 	}
-	ne := len(env)
-	for i := 0; i < ne; i++ {
-		fr.stack[na+i] = env[i]
+	for i := 0; i < pfn.nenv; i++ {
+		fr.stack[pfn.narg+i] = env[i]
 	}
 	fr.run()
 	n := len(fr.results)
@@ -467,13 +465,11 @@ func (i *Interp) callFunctionByReflect(caller *frame, typ reflect.Type, pfn *Fun
 
 func (i *Interp) callFunctionDiscardsResult(caller *frame, pfn *Function, args []value, env []value) {
 	fr := pfn.allocFrame(caller)
-	na := len(args)
-	for i := 0; i < na; i++ {
+	for i := 0; i < pfn.narg; i++ {
 		fr.stack[i] = args[i]
 	}
-	ne := len(env)
-	for i := 0; i < ne; i++ {
-		fr.stack[na+i] = env[i]
+	for i := 0; i < pfn.nenv; i++ {
+		fr.stack[pfn.narg+i] = env[i]
 	}
 	fr.run()
 	pfn.deleteFrame(fr)

--- a/interp.go
+++ b/interp.go
@@ -106,7 +106,6 @@ type Interp struct {
 	typesMutex   sync.RWMutex
 	funcs        map[*ssa.Function]*Function
 	msets        map[reflect.Type](map[string]*ssa.Function) // user defined type method sets
-	rfuns        sync.Map                                    // closure to user defined func id => closure
 }
 
 func (i *Interp) installed(path string) (pkg *Package, ok bool) {
@@ -193,8 +192,7 @@ type frame struct {
 	deferid   int64
 	stack     []value
 	results   []int
-	rfuns     []uintptr // closure to user defined func id
-	cached    bool      // function pool put cached or new
+	cached    bool // function pool put cached or new
 }
 
 func (fr *frame) setReg(index int, v value) {

--- a/interp_test.go
+++ b/interp_test.go
@@ -70,6 +70,7 @@ var testdataTests = []string{
 	"recover2.go",
 	"static.go",
 	"issue23536.go",
+	"tinyfin.go",
 }
 
 func runInput(t *testing.T, input string) bool {

--- a/interp_test.go
+++ b/interp_test.go
@@ -615,3 +615,72 @@ func main() {
 		t.Fatal(s)
 	}
 }
+
+func TestFib(t *testing.T) {
+	src := `package main
+
+import (
+	"sync"
+)
+
+func fib(n int) int {
+	if n < 2 {
+		return n
+	}
+	return fib(n-2) + fib(n-1)
+}
+
+func main() {
+	var wg sync.WaitGroup
+	const N = 10
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			if fib(20) != 6765 {
+				panic("error")
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+`
+	_, err := gossa.RunFile("main.go", src, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFibv(t *testing.T) {
+	src := `package main
+
+import "sync"
+
+func main() {
+	var fib func(n int) int
+	fib = func(n int) int {
+		if n < 2 {
+			return n
+		}
+		return fib(n-2) + fib(n-1)
+	}
+
+	var wg sync.WaitGroup
+	const N = 10
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			if fib(20) != 6765 {
+				panic("error")
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+`
+	_, err := gossa.RunFile("main.go", src, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/opblock.go
+++ b/opblock.go
@@ -1072,9 +1072,10 @@ func makeCallInstr(pfn *Function, interp *Interp, instr ssa.Value, call *ssa.Cal
 			if fn.String() == "runtime.SetFinalizer" {
 				// delete closure from rfuns for gc
 				return func(fr *frame) {
-					v := fr.reg(ia[1])
-					fn := reflect.ValueOf(v)
-					interp.rfuns.Delete(toUserFuncId(&fn))
+					if v := fr.reg(ia[1]); v != nil {
+						fn := reflect.ValueOf(v)
+						interp.rfuns.Delete(toUserFuncId(&fn))
+					}
 					interp.callExternalByStack(fr, ext, ir, ia)
 				}
 			}

--- a/opblock.go
+++ b/opblock.go
@@ -107,7 +107,7 @@ func (p *Function) allocFrame(caller *frame) *frame {
 		fr = p.pool.Get().(*frame)
 	} else {
 		if atomic.AddInt32(&p.used, 1) > int32(p.Interp.ctx.callForPool) {
-			atomic.CompareAndSwapInt32(&p.cached, 0, 1)
+			atomic.StoreInt32(&p.cached, 1)
 		}
 		fr = &frame{interp: p.Interp, pfn: p, block: p.Main}
 		fr.stack = append([]value{}, p.stack...)

--- a/opblock.go
+++ b/opblock.go
@@ -86,6 +86,8 @@ type Function struct {
 	index            map[ssa.Value]uint32 // stack index
 	mapUnderscoreKey map[types.Type]bool
 	pool             *sync.Pool
+	narg             int
+	nenv             int
 }
 
 func (p *Function) initPool() {

--- a/opblock.go
+++ b/opblock.go
@@ -1082,7 +1082,7 @@ func makeCallInstr(pfn *Function, interp *Interp, instr ssa.Value, call *ssa.Cal
 		case *ssa.Function:
 			interp.callFunctionByStack(fr, interp.funcs[fn], ir, ia)
 		case *closure:
-			interp.callFunctionByStack(fr, interp.funcs[fn.Fn], ir, ia)
+			interp.callFunctionByStack(fr, fn.pfn, ir, ia)
 		case *ssa.Builtin:
 			interp.callBuiltinByStack(fr, fn.Name(), call.Args, ir, ia)
 		default:

--- a/ops.go
+++ b/ops.go
@@ -1849,6 +1849,10 @@ func toUnsafePointer(v reflect.Value) unsafe.Pointer {
 	return unsafe.Pointer(uintptr(v.Uint()))
 }
 
+func toUserFuncId(v *reflect.Value) uintptr {
+	return uintptr((*reflectValue)(unsafe.Pointer(v)).ptr)
+}
+
 type reflectValue struct {
 	typ  unsafe.Pointer
 	ptr  unsafe.Pointer

--- a/testdata/tinyfin.go
+++ b/testdata/tinyfin.go
@@ -1,0 +1,64 @@
+// run
+
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Test finalizers work for tiny (combined) allocations.
+
+package main
+
+import (
+	"runtime"
+	"time"
+)
+
+func main() {
+	// Does not work on gccgo due to partially conservative GC.
+	// Try to enable when we have fully precise GC.
+	if runtime.Compiler == "gccgo" {
+		return
+	}
+	const N = 100
+	finalized := make(chan int32, N)
+	for i := 0; i < N; i++ {
+		x := new(int32) // subject to tiny alloc
+		*x = int32(i)
+		// the closure must be big enough to be combined
+		runtime.SetFinalizer(x, func(p *int32) {
+			finalized <- *p
+		})
+	}
+	runtime.GC()
+	count := 0
+	done := make([]bool, N)
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case <-timeout:
+			println("timeout,", count, "finalized so far")
+			panic("not all finalizers are called")
+		case x := <-finalized:
+			// Check that p points to the correct subobject of the tiny allocation.
+			// It's a bit tricky, because we can't capture another variable
+			// with the expected value (it would be combined as well).
+			if x < 0 || x >= N {
+				println("got", x)
+				panic("corrupted")
+			}
+			if done[x] {
+				println("got", x)
+				panic("already finalized")
+			}
+			done[x] = true
+			count++
+			if count > N/10*9 {
+				// Some of the finalizers may not be executed,
+				// if the outermost allocations are combined with something persistent.
+				// Currently 4 int32's are combined into a 16-byte block,
+				// ensure that most of them are finalized.
+				return
+			}
+		}
+	}
+}

--- a/value.go
+++ b/value.go
@@ -9,8 +9,6 @@ import (
 	"reflect"
 	"strings"
 	"unsafe"
-
-	"golang.org/x/tools/go/ssa"
 )
 
 type Value = value
@@ -21,8 +19,8 @@ type value = interface{}
 type tuple []value
 
 type closure struct {
-	Fn  *ssa.Function
-	Env []value
+	pfn *Function
+	env []value
 }
 
 // emptyInterface is the header for an interface{} value.

--- a/visit.go
+++ b/visit.go
@@ -210,12 +210,7 @@ func (visit *visitor) function(fn *ssa.Function) {
 			pfn.Recover = pfn.Instrs[offset:]
 		}
 	}
-	switch fn.Name() {
-	case "init":
-	case "main":
-	default:
-		pfn.initPool()
-	}
+	pfn.initPool()
 }
 
 func loc(fset *token.FileSet, pos token.Pos) string {

--- a/visit.go
+++ b/visit.go
@@ -2,6 +2,7 @@ package gossa
 
 import (
 	"fmt"
+	"go/token"
 	"log"
 	"reflect"
 
@@ -215,4 +216,11 @@ func (visit *visitor) function(fn *ssa.Function) {
 	default:
 		pfn.initPool()
 	}
+}
+
+func loc(fset *token.FileSet, pos token.Pos) string {
+	if pos == token.NoPos {
+		return ""
+	}
+	return " at " + fset.Position(pos).String()
 }

--- a/visit.go
+++ b/visit.go
@@ -3,7 +3,6 @@ package gossa
 import (
 	"fmt"
 	"go/token"
-	"go/types"
 	"log"
 	"reflect"
 
@@ -116,7 +115,6 @@ func (visit *visitor) function(fn *ssa.Function) {
 		for i := 0; i < n; i++ {
 			instr := b.Instrs[i]
 			ops := instr.Operands(buf[:0])
-			var flag int
 			switch instr := instr.(type) {
 			case *ssa.Alloc:
 				visit.intp.loadType(instr.Type())
@@ -143,12 +141,6 @@ func (visit *visitor) function(fn *ssa.Function) {
 				visit.intp.loadType(instr.Type())
 			case *ssa.MakeInterface:
 				visit.intp.loadType(instr.Type())
-			case *ssa.MakeClosure:
-				if i+1 < n {
-					if next, ok := b.Instrs[i+1].(*ssa.Store); ok {
-						flag = checkClosureFlag(instr, next)
-					}
-				}
 			}
 			for _, op := range ops {
 				switch v := (*op).(type) {
@@ -160,7 +152,7 @@ func (visit *visitor) function(fn *ssa.Function) {
 					visit.intp.loadType(v.Type())
 				}
 			}
-			ifn := makeInstr(visit.intp, pfn, instr, flag)
+			ifn := makeInstr(visit.intp, pfn, instr)
 			if ifn == nil {
 				continue
 			}
@@ -227,37 +219,4 @@ func loc(fset *token.FileSet, pos token.Pos) string {
 		return ""
 	}
 	return " at " + fset.Position(pos).String()
-}
-
-const (
-	closureLoop      = 1
-	closureLoopMaybe = 2
-)
-
-func checkClosureFlag(instr *ssa.MakeClosure, next *ssa.Store) int {
-	if next.Val != instr {
-		return 0
-	}
-	// t0 = new func(n int) int (fib)                         *func(n int) int
-	// t1 = make closure main$1 [t0]                           func(n int) int
-	// *t0 = t1
-	for _, b := range instr.Bindings {
-		if b == next.Addr {
-			return closureLoop
-		}
-	}
-	// t0 = new func(n int) int (fib)                         *func(n int) int
-	// t1 = new func(n int) int (fib1)                        *func(n int) int
-	// t2 = make closure main$1 [t0]                           func(n int) int
-	// *t1 = t2
-	for _, b := range instr.Bindings {
-		if alloc, ok := b.(*ssa.Alloc); ok {
-			if ptr, ok := alloc.Type().(*types.Pointer); ok {
-				if _, ok := ptr.Elem().(*types.Signature); ok {
-					return closureLoopMaybe
-				}
-			}
-		}
-	}
-	return 0
 }

--- a/visit.go
+++ b/visit.go
@@ -209,4 +209,10 @@ func (visit *visitor) function(fn *ssa.Function) {
 			pfn.Recover = pfn.Instrs[offset:]
 		}
 	}
+	switch fn.Name() {
+	case "init":
+	case "main":
+	default:
+		pfn.initPool()
+	}
 }


### PR DESCRIPTION
optimize and fast call function and closure

### function pool policy
  **SetLeastCallForEnablePool** set least call count for enable function pool, default 64


### ssa.Function
  function createFrame/deleteFrame by pool check for used count ( default 64) 
```
package main

func fib(n int) int {
	if n < 2 {
		return n
	}
	return fib(n-2) + fib(n-1)
}

func main() {
	println(fib(35))
}

```

### new closure design
https://github.com/visualfc/funcval




### ~~ssa.MakeClosure~~
  1.  closure -> reflect.Func interface and save func id ( interp.rfuns map)
  2.  call  time check user defined func id -> closure for fast call
  3.  delete frame remove id from interp.rfuns map ( for gc)
  4. runtime.SetFinalizer 
    makeCallInstr: check runtime.SetFinalizer and delete closure from rfuns for gc 
**check closure loop or loop maybe for enable store func id**

**closure loop**
```
package main

func main() {
	var fib func(n int) int
	fib = func(n int) int {
		if n < 2 {
			return n
		}
		return fib(n-2) + fib(n-1)
	}
	println(fib(35))
}

```
**closure loop maybe**
```
package main

func main() {
	var fib func(n int) int
	fib1 := func(n int) int {
		return fib(n - 1)
	}
	fib2 := func(n int) int {
		return fib(n - 2)
	}
	fib = func(n int) int {
		if n < 2 {
			return n
		}
		return fib2(n) + fib1(n)
	}
	println(fib(35))
}

```

