### PR TITLE
interp: check runtime.Goexit and os.Exit

### DIFF
--- a/context.go
+++ b/context.go
@@ -183,7 +183,7 @@ func (c *Context) RunPkg(mainPkg *ssa.Package, input string, args []string) (exi
 		return 2, err
 	}
 	if err = interp.RunInit(); err != nil {
-		return 2, fmt.Errorf("init error: %w", err)
+		return 2, err
 	}
 	return interp.RunMain()
 }

--- a/context.go
+++ b/context.go
@@ -182,11 +182,10 @@ func (c *Context) RunPkg(mainPkg *ssa.Package, input string, args []string) (exi
 	if err != nil {
 		return 2, err
 	}
-	_, err = interp.Run("init")
-	if err != nil {
+	if err = interp.RunInit(); err != nil {
 		return 2, fmt.Errorf("init error: %w", err)
 	}
-	return interp.Run("main")
+	return interp.RunMain()
 }
 
 func (c *Context) RunFunc(mainPkg *ssa.Package, fnname string, args ...Value) (ret Value, err error) {
@@ -237,13 +236,12 @@ func (c *Context) TestPkg(pkgs []*ssa.Package, input string, args []string) erro
 			fmt.Printf("create interp failed: %v\n", err)
 			continue
 		}
-		_, err = interp.Run("init")
-		if err != nil {
+		if err = interp.RunInit(); err != nil {
 			failed = true
 			fmt.Printf("init error: %v\n", err)
 			continue
 		}
-		exitCode, _ := interp.Run("main")
+		exitCode, _ := interp.RunMain()
 		if exitCode != 0 {
 			failed = true
 		}

--- a/errors.go
+++ b/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrTestFailed       = errors.New("test failed")
 	ErrNotFoundPackage  = errors.New("not found package")
 	ErrNotFoundImporter = errors.New("not found provider for types.Importer")
+	ErrGoexitDeadlock   = errors.New("fatal error: no goroutines (main called runtime.Goexit) - deadlock!")
 )

--- a/interp.go
+++ b/interp.go
@@ -1005,6 +1005,7 @@ func (i *Interp) ExitCode() int {
 func (i *Interp) RunInit() (err error) {
 	i.goexited = false
 	i.exited = false
+	i.exitCode = 0
 	_, err = i.RunFunc("init")
 	return
 }
@@ -1013,12 +1014,14 @@ func (i *Interp) RunMain() (exitCode int, err error) {
 	if i.exited {
 		return i.exitCode, nil
 	}
-	i.exitCode = 2
 	_, err = i.RunFunc("main")
-	if err == nil && !i.exited {
-		i.exitCode = 0
+	if err != nil {
+		exitCode = 2
 	}
-	return i.exitCode, err
+	if i.exited {
+		exitCode = i.exitCode
+	}
+	return
 }
 
 func (i *Interp) GetFunc(key string) (interface{}, bool) {

--- a/interp.go
+++ b/interp.go
@@ -977,7 +977,7 @@ func (i *Interp) RunFunc(name string, args ...Value) (r Value, err error) {
 		case goexitPanic:
 			// check goroutines
 			if atomic.LoadInt32(&i.goroutines) == 1 {
-				err = plainError("fatal error: no goroutines (main called runtime.Goexit) - deadlock!")
+				err = ErrGoexitDeadlock
 			} else {
 				atomic.StoreInt32(&i.goexited, 1)
 				i.exitCode = <-i.chexit

--- a/interp_test.go
+++ b/interp_test.go
@@ -2098,3 +2098,36 @@ true
 		t.Fatal("error")
 	}
 }
+
+func TestGoexit(t *testing.T) {
+	src := `package main
+
+import (
+	"os"
+	"runtime"
+)
+
+func init() {
+	c := make(chan int, 1)
+	defer func() {
+		c <- 1
+	}()
+	go func() {
+		os.Exit(<-c)
+	}()
+	runtime.Goexit()
+	os.Exit(-1)
+}
+
+func main() {
+	os.Exit(-2)
+}
+`
+	code, err := gossa.RunFile("main.go", src, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 1 {
+		t.Fatalf("error exit code %v", code)
+	}
+}

--- a/interp_test.go
+++ b/interp_test.go
@@ -2130,3 +2130,28 @@ func main() {
 		t.Fatalf("error exit code %v", code)
 	}
 }
+
+func TestGoexitDeadlock(t *testing.T) {
+	src := `package main
+import (
+	"os"
+	"runtime"
+)
+
+func init() {
+	runtime.Goexit()
+	os.Exit(-1)
+}
+
+func main() {
+	os.Exit(-2)
+}
+`
+	_, err := gossa.RunFile("main.go", src, nil, 0)
+	if err == nil {
+		t.Fatal("must panic")
+	}
+	if err.Error() != gossa.ErrGoexitDeadlock.Error() {
+		t.Fatal(err)
+	}
+}

--- a/interp_test.go
+++ b/interp_test.go
@@ -2101,7 +2101,6 @@ true
 
 func TestGoexit(t *testing.T) {
 	src := `package main
-
 import (
 	"os"
 	"runtime"

--- a/opblock.go
+++ b/opblock.go
@@ -205,7 +205,7 @@ func findExternFunc(interp *Interp, fn *ssa.Function) (ext reflect.Value, ok boo
 	fnName := fn.String()
 	if fnName == "os.Exit" {
 		return reflect.ValueOf(func(code int) {
-			if interp.goexited {
+			if atomic.LoadInt32(&interp.goexited) == 1 {
 				//os.Exit(code)
 				interp.chexit <- code
 			} else {

--- a/ops.go
+++ b/ops.go
@@ -32,6 +32,8 @@ func (p targetPanic) Error() string {
 // If the target program calls exit, the interpreter panics with this type.
 type exitPanic int
 
+type goexitPanic int
+
 func xtypeValue(c *ssa.Const, kind types.BasicKind) value {
 	switch kind {
 	case types.Bool, types.UntypedBool:


### PR DESCRIPTION
fix call runtime.Goexit and os.Exit

gossa os.Exit
```
if atomic.LoadInt32(&interp.goexited) == 1 {
//os.Exit(code)
    interp.chexit <- code
} else {
    panic(exitPanic(code))
}
```
gossa runtime.Goexit
```
// main goroutine use panic
if goroutineId() == interp.mainid {
	panic(goexitPanic(0))
} else {
	runtime.Goexit()
}
```

defer func
```
case exitPanic:
	i.exitCode = int(p)
	atomic.StoreInt32(&i.exited, 1)
case goexitPanic:
	// check goroutines
	if atomic.LoadInt32(&i.goroutines) == 1 {
		err = plainError("fatal error: no goroutines (main called runtime.Goexit) - deadlock!")
	} else {
		atomic.StoreInt32(&i.goexited, 1)
		i.exitCode = <-i.chexit
		atomic.StoreInt32(&i.exited, 1)
        }
```

