### PR TITLE
support custom builtin function

### DIFF
--- a/context.go
+++ b/context.go
@@ -400,13 +400,13 @@ func init() {
 	RegisterPackage(builtinPkg)
 }
 
-func RegisterBuiltin(key string, fn interface{}) {
+func RegisterBuiltin(key string, fn interface{}) error {
 	v := reflect.ValueOf(fn)
-	if !strings.HasPrefix(key, builtinPrefix) {
-		key = builtinPrefix + key
-	}
 	switch v.Kind() {
 	case reflect.Func:
+		if !strings.HasPrefix(key, builtinPrefix) {
+			key = builtinPrefix + key
+		}
 		builtinPkg.Funcs[key] = v
 		typ := v.Type()
 		for i := 0; i < typ.NumIn(); i++ {
@@ -415,7 +415,9 @@ func RegisterBuiltin(key string, fn interface{}) {
 		for i := 0; i < typ.NumOut(); i++ {
 			checkBuiltinDeps(typ.Out(i))
 		}
+		return nil
 	}
+	return ErrNoFunction
 }
 
 func checkBuiltinDeps(typ reflect.Type) {

--- a/context.go
+++ b/context.go
@@ -375,11 +375,18 @@ func RunTest(path string, args []string, mode Mode) error {
 
 var (
 	builtinPkg = &Package{
-		Name:  "builtin",
-		Path:  "github.com/goplus/gossa/builtin",
-		Funcs: make(map[string]reflect.Value),
-		Deps:  make(map[string]string),
+		Name:          "builtin",
+		Path:          "github.com/goplus/gossa/builtin",
+		Deps:          make(map[string]string),
+		Interfaces:    map[string]reflect.Type{},
+		NamedTypes:    map[string]NamedType{},
+		AliasTypes:    map[string]reflect.Type{},
+		Vars:          map[string]reflect.Value{},
+		Funcs:         map[string]reflect.Value{},
+		TypedConsts:   map[string]TypedConst{},
+		UntypedConsts: map[string]UntypedConst{},
 	}
+	builtinPrefix = "Builtin_"
 )
 
 func init() {
@@ -388,9 +395,12 @@ func init() {
 
 func RegisterBuiltin(key string, fn interface{}) {
 	v := reflect.ValueOf(fn)
+	if !strings.HasPrefix(key, builtinPrefix) {
+		key = builtinPrefix + key
+	}
 	switch v.Kind() {
 	case reflect.Func:
-		builtinPkg.Funcs["Gossa_"+key] = v
+		builtinPkg.Funcs[key] = v
 		typ := v.Type()
 		for i := 0; i < typ.NumIn(); i++ {
 			checkBuiltinDeps(typ.In(i))

--- a/errors.go
+++ b/errors.go
@@ -10,4 +10,5 @@ var (
 	ErrNotFoundPackage  = errors.New("not found package")
 	ErrNotFoundImporter = errors.New("not found provider for types.Importer")
 	ErrGoexitDeadlock   = errors.New("fatal error: no goroutines (main called runtime.Goexit) - deadlock!")
+	ErrNoFunction       = errors.New("no function")
 )

--- a/interp_test.go
+++ b/interp_test.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -2140,5 +2141,26 @@ func main() {
 	_, err := gossa.RunFile("main.go", src, nil, 0)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestRegisterBuiltin(t *testing.T) {
+	src := `package main
+
+func main() {
+	dump_info(typeof("hello"))
+}
+`
+	gossa.RegisterBuiltin("typeof", reflect.TypeOf)
+	var info interface{}
+	gossa.RegisterBuiltin("dump_info", func(v interface{}) {
+		info = v
+	})
+	_, err := gossa.RunFile("main.go", src, nil, 0)
+	if err != nil {
+		panic(err)
+	}
+	if info != reflect.TypeOf("hello") {
+		panic("error")
 	}
 }

--- a/opblock.go
+++ b/opblock.go
@@ -5,7 +5,6 @@ import (
 	"go/token"
 	"go/types"
 	"io"
-	"log"
 	"reflect"
 	"runtime"
 	"strings"
@@ -1078,9 +1077,6 @@ func makeCallInstr(pfn *function, interp *Interp, instr ssa.Value, call *ssa.Cal
 	typ := interp.preToType(call.Value.Type())
 	if typ.Kind() != reflect.Func {
 		panic("unsupport")
-	}
-	if unop, ok := call.Value.(*ssa.UnOp); ok {
-		log.Printf("~~~~~~~ %T\n", unop.X)
 	}
 	return func(fr *frame) {
 		fn := fr.reg(iv)

--- a/opblock.go
+++ b/opblock.go
@@ -5,6 +5,7 @@ import (
 	"go/token"
 	"go/types"
 	"io"
+	"log"
 	"reflect"
 	"runtime"
 	"strings"
@@ -1067,6 +1068,9 @@ func makeCallInstr(pfn *function, interp *Interp, instr ssa.Value, call *ssa.Cal
 	typ := interp.preToType(call.Value.Type())
 	if typ.Kind() != reflect.Func {
 		panic("unsupport")
+	}
+	if unop, ok := call.Value.(*ssa.UnOp); ok {
+		log.Printf("~~~~~~~ %T\n", unop.X)
 	}
 	return func(fr *frame) {
 		fn := fr.reg(iv)


### PR DESCRIPTION
fix https://github.com/goplus/gossa/issues/87
```
package main

import (
	"fmt"
	"reflect"

	"github.com/goplus/gossa"
)

var src = `package main

func main() {
	println(typeof("hello"))
}
`

func main() {
	gossa.RegisterBuiltin("typeof", reflect.TypeOf)
	gossa.RegisterBuiltin("println", fmt.Println)
	gossa.RunFile("main.go", src, nil, 0)
}

```